### PR TITLE
Add mobile metadata to .desktop file

### DIFF
--- a/data/io.github.mrvladus.List.desktop
+++ b/data/io.github.mrvladus.List.desktop
@@ -6,3 +6,5 @@ Terminal=false
 Type=Application
 Categories=GNOME;GTK;Utility;
 StartupNotify=true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This will enable the app to appear on the default home screen without needing to toggle the All Apps view.

Code taken from Flatseal: https://github.com/tchx84/Flatseal/blob/master/data/com.github.tchx84.Flatseal.desktop.in#L12C1-L13

Fixes: #24